### PR TITLE
Release profile

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,7 +40,7 @@ jobs:
         git config user.email "actions@github.com"
         git config user.name "GitHub Actions"
 
-        ./mvnw -B release:prepare release:perform -Dusername=$GITHUB_ACTOR -Dpassword=$GITHUB_TOKEN
+        ./mvnw -B release:prepare release:perform -Dusername=$GITHUB_ACTOR -Dpassword=$GITHUB_TOKEN -P release
       env:
         OSSRH_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>0.0.17</version>
+  <version>0.0.18-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>
@@ -55,7 +55,7 @@
     <connection>scm:git:git://github.com/stratospheric-dev/cdk-constructs.git</connection>
     <developerConnection>scm:git:https://github.com/stratospheric-dev/cdk-constructs.git</developerConnection>
     <url>https://github.com/stratospheric-dev/cdk-constructs</url>
-    <tag>cdk-constructs-0.0.17</tag>
+    <tag>cdk-constructs-0.0.16</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>0.0.19</version>
+  <version>0.0.20-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>
@@ -55,7 +55,7 @@
     <connection>scm:git:git://github.com/stratospheric-dev/cdk-constructs.git</connection>
     <developerConnection>scm:git:https://github.com/stratospheric-dev/cdk-constructs.git</developerConnection>
     <url>https://github.com/stratospheric-dev/cdk-constructs</url>
-    <tag>cdk-constructs-0.0.19</tag>
+    <tag>cdk-constructs-0.0.16</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>0.0.18-SNAPSHOT</version>
+  <version>0.0.18</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>
@@ -55,7 +55,7 @@
     <connection>scm:git:git://github.com/stratospheric-dev/cdk-constructs.git</connection>
     <developerConnection>scm:git:https://github.com/stratospheric-dev/cdk-constructs.git</developerConnection>
     <url>https://github.com/stratospheric-dev/cdk-constructs</url>
-    <tag>cdk-constructs-0.0.16</tag>
+    <tag>cdk-constructs-0.0.18</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>0.0.17-SNAPSHOT</version>
+  <version>0.0.17</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>
@@ -55,7 +55,7 @@
     <connection>scm:git:git://github.com/stratospheric-dev/cdk-constructs.git</connection>
     <developerConnection>scm:git:https://github.com/stratospheric-dev/cdk-constructs.git</developerConnection>
     <url>https://github.com/stratospheric-dev/cdk-constructs</url>
-    <tag>cdk-constructs-0.0.16</tag>
+    <tag>cdk-constructs-0.0.17</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>0.0.18</version>
+  <version>0.0.19-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>
@@ -55,7 +55,7 @@
     <connection>scm:git:git://github.com/stratospheric-dev/cdk-constructs.git</connection>
     <developerConnection>scm:git:https://github.com/stratospheric-dev/cdk-constructs.git</developerConnection>
     <url>https://github.com/stratospheric-dev/cdk-constructs</url>
-    <tag>cdk-constructs-0.0.18</tag>
+    <tag>cdk-constructs-0.0.16</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>0.0.19-SNAPSHOT</version>
+  <version>0.0.19</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>
@@ -55,7 +55,7 @@
     <connection>scm:git:git://github.com/stratospheric-dev/cdk-constructs.git</connection>
     <developerConnection>scm:git:https://github.com/stratospheric-dev/cdk-constructs.git</developerConnection>
     <url>https://github.com/stratospheric-dev/cdk-constructs</url>
-    <tag>cdk-constructs-0.0.16</tag>
+    <tag>cdk-constructs-0.0.19</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>dev.stratospheric</groupId>
@@ -68,6 +69,47 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <dependencies>
     <dependency>
@@ -167,41 +209,10 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.6</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-            <configuration>
-              <gpgArguments>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.1.0</version>
         <configuration>
           <addDefaultExcludes>false</addDefaultExcludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>0.0.20-SNAPSHOT</version>
+  <version>0.0.18-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>


### PR DESCRIPTION
If I ran `mvn install` locally, it would fail because it can't find the signing keys, so I moved the signing into the `release` profile, so that it's only executed in the CI build.