### PR TITLE
Network construct: Make sslCertificateArn parameter optional (Part 2 of 2)

### DIFF
--- a/src/main/java/dev/stratospheric/cdk/Network.java
+++ b/src/main/java/dev/stratospheric/cdk/Network.java
@@ -125,7 +125,7 @@ public class Network extends Construct {
   private static Optional<String> getHttpsListenerArnFromParameterStore(Construct scope, String environmentName) {
     String value = StringParameter.fromStringParameterName(scope, PARAMETER_HTTPS_LISTENER, createParameterName(environmentName, PARAMETER_HTTPS_LISTENER))
       .getStringValue();
-    if (value.equals("null")) {
+    if ("null".equals(value)) {
       return Optional.empty();
     } else {
       return Optional.ofNullable(value);
@@ -427,8 +427,7 @@ public class Network extends Construct {
      *                          the load balancer will only listen to plain HTTP.
      */
     public NetworkInputParameters(String sslCertificateArn) {
-      Objects.requireNonNull(sslCertificateArn);
-      this.sslCertificateArn = Optional.of(sslCertificateArn);
+      this.sslCertificateArn = Optional.ofNullable(sslCertificateArn);
     }
 
     public NetworkInputParameters() {

--- a/src/main/java/dev/stratospheric/cdk/Network.java
+++ b/src/main/java/dev/stratospheric/cdk/Network.java
@@ -419,19 +419,27 @@ public class Network extends Construct {
   }
 
   public static class NetworkInputParameters {
-    private final Optional<String> sslCertificateArn;
+    private Optional<String> sslCertificateArn;
 
     /**
      * @param sslCertificateArn the ARN of the SSL certificate that the load balancer will use
      *                          to terminate HTTPS communication. If no SSL certificate is passed,
      *                          the load balancer will only listen to plain HTTP.
+     * @deprecated use {@link #withSslCertificateArn(String)} instead
      */
+    @Deprecated
     public NetworkInputParameters(String sslCertificateArn) {
       this.sslCertificateArn = Optional.ofNullable(sslCertificateArn);
     }
 
     public NetworkInputParameters() {
       this.sslCertificateArn = Optional.empty();
+    }
+
+    public NetworkInputParameters withSslCertificateArn(String sslCertificateArn){
+      Objects.requireNonNull(sslCertificateArn);
+      this.sslCertificateArn = Optional.of(sslCertificateArn);
+      return this;
     }
 
     public Optional<String> getSslCertificateArn() {


### PR DESCRIPTION
The Network construct specifies that the SSL configuration is optional. 
However, the SSL Certificate ARN is required when creating the NetworkInputParameter class with the String constuctor.

This PR allows the given sslCertificateArn parameter to be null and create the corresponding Optional object accordingly.

It also fixes a possible NullPointerException when retrieving the HTTPS LISTENER parameter.

This PR is the part 2 of 2 to make SSL configuration optional. See other Pull Request on stratospheric project: PR #54 (https://github.com/stratospheric-dev/stratospheric/pull/54)