### PR TITLE
explicitly specify HTTPS protocol for the redirect

### DIFF
--- a/src/main/java/dev/stratospheric/cdk/Network.java
+++ b/src/main/java/dev/stratospheric/cdk/Network.java
@@ -1,21 +1,43 @@
 package dev.stratospheric.cdk;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.Environment;
-import software.amazon.awscdk.core.Tags;
-import software.amazon.awscdk.services.ec2.*;
-import software.amazon.awscdk.services.ecs.Cluster;
-import software.amazon.awscdk.services.ecs.ICluster;
-import software.amazon.awscdk.services.elasticloadbalancingv2.*;
-import software.amazon.awscdk.services.ssm.StringParameter;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import software.amazon.awscdk.core.Construct;
+import software.amazon.awscdk.core.Environment;
+import software.amazon.awscdk.core.Tags;
+import software.amazon.awscdk.services.ec2.CfnSecurityGroupIngress;
+import software.amazon.awscdk.services.ec2.ISecurityGroup;
+import software.amazon.awscdk.services.ec2.ISubnet;
+import software.amazon.awscdk.services.ec2.IVpc;
+import software.amazon.awscdk.services.ec2.SecurityGroup;
+import software.amazon.awscdk.services.ec2.SubnetConfiguration;
+import software.amazon.awscdk.services.ec2.SubnetType;
+import software.amazon.awscdk.services.ec2.Vpc;
+import software.amazon.awscdk.services.ecs.Cluster;
+import software.amazon.awscdk.services.ecs.ICluster;
+import software.amazon.awscdk.services.elasticloadbalancingv2.AddApplicationTargetGroupsProps;
+import software.amazon.awscdk.services.elasticloadbalancingv2.ApplicationListenerRule;
+import software.amazon.awscdk.services.elasticloadbalancingv2.ApplicationListenerRuleProps;
+import software.amazon.awscdk.services.elasticloadbalancingv2.ApplicationLoadBalancer;
+import software.amazon.awscdk.services.elasticloadbalancingv2.ApplicationProtocol;
+import software.amazon.awscdk.services.elasticloadbalancingv2.ApplicationTargetGroup;
+import software.amazon.awscdk.services.elasticloadbalancingv2.BaseApplicationListenerProps;
+import software.amazon.awscdk.services.elasticloadbalancingv2.IApplicationListener;
+import software.amazon.awscdk.services.elasticloadbalancingv2.IApplicationLoadBalancer;
+import software.amazon.awscdk.services.elasticloadbalancingv2.IApplicationTargetGroup;
+import software.amazon.awscdk.services.elasticloadbalancingv2.IListenerCertificate;
+import software.amazon.awscdk.services.elasticloadbalancingv2.ListenerAction;
+import software.amazon.awscdk.services.elasticloadbalancingv2.ListenerCertificate;
+import software.amazon.awscdk.services.elasticloadbalancingv2.ListenerCondition;
+import software.amazon.awscdk.services.elasticloadbalancingv2.RedirectOptions;
+import software.amazon.awscdk.services.elasticloadbalancingv2.TargetType;
+import software.amazon.awscdk.services.ssm.StringParameter;
 
 import static java.util.Arrays.asList;
 
@@ -308,6 +330,7 @@ public class Network extends Construct {
 
       ListenerAction redirectAction = ListenerAction.redirect(
         RedirectOptions.builder()
+          .protocol("HTTPS")
           .port("443")
           .build()
       );


### PR DESCRIPTION
Otherwise, the redirect rule is `#{protocol}://#{host}:443/#{path}?#{query}` which result in a bad request as we try to access the HTTPS port over HTTP:

<img width="1433" alt="grafik" src="https://user-images.githubusercontent.com/14176609/142420373-10d34dff-09cf-4885-98b6-5e96d2dedbfa.png">

```
curl -v http://app.utilzr.io
*   Trying 52.59.170.60...
* TCP_NODELAY set
* Connected to app.utilzr.io (52.59.170.60) port 80 (#0)
> GET / HTTP/1.1
> Host: app.utilzr.io
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 302 Moved Temporarily
< Server: awselb/2.0
< Date: Thu, 18 Nov 2021 13:03:12 GMT
< Content-Type: text/html
< Content-Length: 110
< Connection: keep-alive
< Location: http://app.utilzr.io:443/
<
<html>
<head><title>302 Found</title></head>
<body>
<center><h1>302 Found</h1></center>
</body>
</html>
* Connection #0 to host app.utilzr.io left intact
* Closing connection 0
* 
```