### PR TITLE
Migrate the constructs library to AWS CDK v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:00"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The constructs have been built to deploy a real application into production and 
 
 These constructs are explained in further detail in [our book](https://stratospheric.dev).
 
-Starting from version 0.1.0, this constructs library only supports the AWS CDK v2. For migrating your existing AWS CDK v1 setup, follow the [official AWS migration guide](https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html).
+From version 0.1.0 onwards, this constructs library only supports the AWS CDK v2. For migrating your existing AWS CDK v1 setup, follow the [official AWS migration guide](https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The constructs have been built to deploy a real application into production and 
 
 These constructs are explained in further detail in [our book](https://stratospheric.dev).
 
+Starting from version 0.0.XX, this constructs library supports AWS CDK v2. For migrating your AWS CDK v1 setup, follow the [official AWS migration guide](https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html).
+
 ## Installation
 
 Load the dependency from Maven Central by adding this to your `pom.xml`:
@@ -34,6 +36,20 @@ implementation('dev.stratospheric:cdk-constructs:${latestVersion}')
 The `latestVersion` is: [![](https://img.shields.io/maven-central/v/dev.stratospheric/cdk-constructs.svg?label=)](https://search.maven.org/search?q=g:%22dev.stratospheric%22%20AND%20a:%22cdk-constructs%22)
 
 Use this version without the `v` prefix inside your `pom.xml` or `build.gradle`: `v0.0.13` -> `0.0.13`.
+
+To override the version of the AWS Java CDK library, use a `<dependencyManagement>` inside your `pom.xml`:
+
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>software.amazon.awscdk</groupId>
+      <artifactId>aws-cdk-lib</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
 
 ## Construct Overview
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The constructs have been built to deploy a real application into production and 
 
 These constructs are explained in further detail in [our book](https://stratospheric.dev).
 
-Starting from version 0.0.XX, this constructs library supports AWS CDK v2. For migrating your AWS CDK v1 setup, follow the [official AWS migration guide](https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html).
+Starting from version 0.1.0, this constructs library only supports the AWS CDK v2. For migrating your existing AWS CDK v1 setup, follow the [official AWS migration guide](https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html).
 
 ## Installation
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>0.0.26-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>0.0.26-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>dev.stratospheric</groupId>
   <artifactId>cdk-constructs</artifactId>
-  <version>0.0.26-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CDK Constructs</name>
@@ -15,7 +16,8 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <cdk.version>1.121.0</cdk.version>
+    <aws-cdk-lib.version>2.3.0</aws-cdk-lib.version>
+    <constructs.version>10.0.17</constructs.version>
   </properties>
 
   <organization>
@@ -105,58 +107,20 @@
     </profile>
   </profiles>
 
+<dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>software.amazon.awscdk</groupId>
-      <artifactId>core</artifactId>
-      <version>${cdk.version}</version>
+      <artifactId>aws-cdk-lib</artifactId>
+      <version>${aws-cdk-lib.version}</version>
     </dependency>
     <dependency>
-      <groupId>software.amazon.awscdk</groupId>
-      <artifactId>ec2</artifactId>
-      <version>${cdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awscdk</groupId>
-      <artifactId>elasticloadbalancingv2</artifactId>
-      <version>${cdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awscdk</groupId>
-      <artifactId>autoscaling</artifactId>
-      <version>${cdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awscdk</groupId>
-      <artifactId>rds</artifactId>
-      <version>${cdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awscdk</groupId>
-      <artifactId>secretsmanager</artifactId>
-      <version>${cdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awscdk</groupId>
-      <artifactId>ecr</artifactId>
-      <version>${cdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awscdk</groupId>
-      <artifactId>iam</artifactId>
-      <version>${cdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awscdk</groupId>
-      <artifactId>ecs</artifactId>
-      <version>${cdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awscdk</groupId>
-      <artifactId>ssm</artifactId>
-      <version>${cdk.version}</version>
+      <groupId>software.constructs</groupId>
+      <artifactId>constructs</artifactId>
+      <version>${constructs.version}</version>
     </dependency>
   </dependencies>
+</dependencyManagement>
 
   <build>
     <extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
     </profile>
   </profiles>
 
-<dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>software.amazon.awscdk</groupId>
@@ -120,7 +119,6 @@
       <version>${constructs.version}</version>
     </dependency>
   </dependencies>
-</dependencyManagement>
 
   <build>
     <extensions>

--- a/src/main/java/dev/stratospheric/cdk/ApplicationEnvironment.java
+++ b/src/main/java/dev/stratospheric/cdk/ApplicationEnvironment.java
@@ -1,7 +1,7 @@
 package dev.stratospheric.cdk;
 
-import software.amazon.awscdk.core.IConstruct;
-import software.amazon.awscdk.core.Tags;
+import software.amazon.awscdk.Tags;
+import software.constructs.IConstruct;
 
 /**
  * An application can be deployed into multiple environments (staging, production, ...).

--- a/src/main/java/dev/stratospheric/cdk/DockerRepository.java
+++ b/src/main/java/dev/stratospheric/cdk/DockerRepository.java
@@ -1,15 +1,15 @@
 package dev.stratospheric.cdk;
 
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.Environment;
-import software.amazon.awscdk.core.RemovalPolicy;
+import java.util.Collections;
+import java.util.Objects;
+
+import software.amazon.awscdk.Environment;
+import software.amazon.awscdk.RemovalPolicy;
 import software.amazon.awscdk.services.ecr.IRepository;
 import software.amazon.awscdk.services.ecr.LifecycleRule;
 import software.amazon.awscdk.services.ecr.Repository;
 import software.amazon.awscdk.services.iam.AccountPrincipal;
-
-import java.util.Collections;
-import java.util.Objects;
+import software.constructs.Construct;
 
 /**
  * Provisions an ECR repository for Docker images. Every user in the given account will have access

--- a/src/main/java/dev/stratospheric/cdk/JumpHost.java
+++ b/src/main/java/dev/stratospheric/cdk/JumpHost.java
@@ -1,13 +1,13 @@
 package dev.stratospheric.cdk;
 
-import software.amazon.awscdk.core.CfnOutput;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.Environment;
+import java.util.Objects;
+
+import software.amazon.awscdk.CfnOutput;
+import software.amazon.awscdk.Environment;
 import software.amazon.awscdk.services.ec2.CfnInstance;
 import software.amazon.awscdk.services.ec2.CfnSecurityGroup;
 import software.amazon.awscdk.services.ec2.CfnSecurityGroupIngress;
-
-import java.util.Objects;
+import software.constructs.Construct;
 
 import static java.util.Collections.singletonList;
 

--- a/src/main/java/dev/stratospheric/cdk/Network.java
+++ b/src/main/java/dev/stratospheric/cdk/Network.java
@@ -8,9 +8,8 @@ import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.Environment;
-import software.amazon.awscdk.core.Tags;
+import software.amazon.awscdk.Environment;
+import software.amazon.awscdk.Tags;
 import software.amazon.awscdk.services.ec2.CfnSecurityGroupIngress;
 import software.amazon.awscdk.services.ec2.ISecurityGroup;
 import software.amazon.awscdk.services.ec2.ISubnet;
@@ -38,6 +37,7 @@ import software.amazon.awscdk.services.elasticloadbalancingv2.ListenerCondition;
 import software.amazon.awscdk.services.elasticloadbalancingv2.RedirectOptions;
 import software.amazon.awscdk.services.elasticloadbalancingv2.TargetType;
 import software.amazon.awscdk.services.ssm.StringParameter;
+import software.constructs.Construct;
 
 import static java.util.Arrays.asList;
 
@@ -252,7 +252,7 @@ public class Network extends Construct {
       .build();
 
     SubnetConfiguration isolatedSubnets = SubnetConfiguration.builder()
-      .subnetType(SubnetType.ISOLATED)
+      .subnetType(SubnetType.PRIVATE_ISOLATED)
       .name(prefixWithEnvironmentName("isolatedSubnet"))
       .build();
 

--- a/src/main/java/dev/stratospheric/cdk/PostgresDatabase.java
+++ b/src/main/java/dev/stratospheric/cdk/PostgresDatabase.java
@@ -1,8 +1,10 @@
 package dev.stratospheric.cdk;
 
+import java.util.Collections;
+import java.util.Objects;
+
 import org.jetbrains.annotations.NotNull;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.Environment;
+import software.amazon.awscdk.Environment;
 import software.amazon.awscdk.services.ec2.CfnSecurityGroup;
 import software.amazon.awscdk.services.rds.CfnDBInstance;
 import software.amazon.awscdk.services.rds.CfnDBSubnetGroup;
@@ -11,9 +13,7 @@ import software.amazon.awscdk.services.secretsmanager.ISecret;
 import software.amazon.awscdk.services.secretsmanager.Secret;
 import software.amazon.awscdk.services.secretsmanager.SecretStringGenerator;
 import software.amazon.awscdk.services.ssm.StringParameter;
-
-import java.util.Collections;
-import java.util.Objects;
+import software.constructs.Construct;
 
 /**
  * Creates a Postgres database in the isolated subnets of a given VPC.

--- a/src/main/java/dev/stratospheric/cdk/Service.java
+++ b/src/main/java/dev/stratospheric/cdk/Service.java
@@ -1,7 +1,17 @@
 package dev.stratospheric.cdk;
 
-import org.jetbrains.annotations.NotNull;
-import software.amazon.awscdk.core.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import software.amazon.awscdk.CfnCondition;
+import software.amazon.awscdk.Environment;
+import software.amazon.awscdk.Fn;
+import software.amazon.awscdk.RemovalPolicy;
 import software.amazon.awscdk.services.ec2.CfnSecurityGroup;
 import software.amazon.awscdk.services.ec2.CfnSecurityGroupIngress;
 import software.amazon.awscdk.services.ecr.IRepository;
@@ -9,13 +19,15 @@ import software.amazon.awscdk.services.ecr.Repository;
 import software.amazon.awscdk.services.ecs.CfnService;
 import software.amazon.awscdk.services.ecs.CfnTaskDefinition;
 import software.amazon.awscdk.services.elasticloadbalancingv2.CfnListenerRule;
-import software.amazon.awscdk.services.elasticloadbalancingv2.CfnListenerRule.Builder;
 import software.amazon.awscdk.services.elasticloadbalancingv2.CfnTargetGroup;
-import software.amazon.awscdk.services.iam.*;
+import software.amazon.awscdk.services.iam.Effect;
+import software.amazon.awscdk.services.iam.PolicyDocument;
+import software.amazon.awscdk.services.iam.PolicyStatement;
+import software.amazon.awscdk.services.iam.Role;
+import software.amazon.awscdk.services.iam.ServicePrincipal;
 import software.amazon.awscdk.services.logs.LogGroup;
 import software.amazon.awscdk.services.logs.RetentionDays;
-
-import java.util.*;
+import software.constructs.Construct;
 
 import static java.util.Collections.singletonList;
 

--- a/src/main/java/dev/stratospheric/cdk/SpringBootApplicationStack.java
+++ b/src/main/java/dev/stratospheric/cdk/SpringBootApplicationStack.java
@@ -1,8 +1,13 @@
 package dev.stratospheric.cdk;
 
-import software.amazon.awscdk.core.*;
-
 import java.util.Collections;
+
+import software.amazon.awscdk.CfnOutput;
+import software.amazon.awscdk.CfnOutputProps;
+import software.amazon.awscdk.Environment;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+import software.constructs.Construct;
 
 /**
  * This stack creates a {@link Network} and a {@link Service} that deploys a given Docker image. The {@link Service} is


### PR DESCRIPTION
This brings the required changes to use the AWS Java SDK v2 for our constructs library.