### PR TITLE
fix: Replace SecretValue#toString usage

### DIFF
--- a/src/main/java/dev/stratospheric/cdk/PostgresDatabase.java
+++ b/src/main/java/dev/stratospheric/cdk/PostgresDatabase.java
@@ -104,7 +104,7 @@ public class PostgresDatabase extends Construct {
       .engine("postgres")
       .engineVersion(databaseInputParameters.postgresVersion)
       .masterUsername(username)
-      .masterUserPassword(databaseSecret.secretValueFromJson("password").toString())
+      .masterUserPassword(databaseSecret.secretValueFromJson("password").unsafeUnwrap())
       .publiclyAccessible(false)
       .vpcSecurityGroups(Collections.singletonList(databaseSecurityGroup.getAttrGroupId()))
       .build();


### PR DESCRIPTION
Using `toString` on secrets seems to be no longer accepted without calling `unsafeUnwrap` first.
Similarly to [PR#234 from stratospheric repository](https://github.com/stratospheric-dev/stratospheric/pull/234), I'm proposing to replace `SecretValue#toString` usage with usage of `SecretValue#unsafeUnwrap`.